### PR TITLE
#26 Add bothelp command to list commands available

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import os
 
-import asyncio
 import discord
 from discord.ext import commands
 from discord.ext.commands import Bot
@@ -63,10 +62,28 @@ def main():
 
     # Discord bot commands
     @bot.command()
-    async def marco(ctx):
+    async def bothelp(ctx):
         async with ctx.typing():
-            await asyncio.sleep(0.5)
-        await ctx.send('Polo! Bot is up and running!')
+            embed = discord.Embed(
+                description=dedent('''
+                This bot provides a variety of useful commands to help with clan management.
+                '''),
+                colour=discord.Colour.purple()
+            )
+            ausclan_cmds = [
+                '**`!ausclan [filter]`** - Shows clan members ranked by number of high level cards they have. [filter] '
+                'can be one of \'all\', \'troop\', \'spell\' or \'building\'. Defaults to \'all\' if not specified',
+                '**`!ausclanboat`** - Lists clan members who attacked enemy boats this week.',
+            ]
+            generic_cmds = [
+                '**`!bothelp`** - Shows this help message about available commands.',
+                '**`!membercardsranked [clan_tag] [filter]`** - Does the same thing as `!ausclan` but '
+                'for the specific [clan_tag] instead.',
+                '**`!boatattack [clan_tag]`** - Does the same thing as `!ausclanboat` but for the specific [clan_tag] instead.'
+            ]
+            embed.add_field(name='Ausclan commands', value='\n\n'.join(ausclan_cmds), inline=False)
+            embed.add_field(name='Other commands', value='\n\n'.join(generic_cmds), inline=False)
+        await ctx.send(embed=embed)
 
     @bot.command()
     async def membercardsranked(ctx, *args):

--- a/main.py
+++ b/main.py
@@ -70,19 +70,20 @@ def main():
                 '''),
                 colour=discord.Colour.purple()
             )
+            url = 'https://royaleapi.com/clan/9GULPJ9L/war/race'
             ausclan_cmds = [
-                '**`!ausclan [filter]`** - Shows clan members ranked by number of high level cards they have. [filter] '
+                f'[!ausclan \[filter\]]({url}) - Shows clan members ranked by number of high level cards they have. [filter] '
                 'can be one of \'all\', \'troop\', \'spell\' or \'building\'. Defaults to \'all\' if not specified',
-                '**`!ausclanboat`** - Lists clan members who attacked enemy boats this week.',
+                f'[!ausclanboat]({url}) - Lists clan members who attacked enemy boats this week.',
             ]
             generic_cmds = [
-                '**`!bothelp`** - Shows this help message about available commands.',
-                '**`!membercardsranked [clan_tag] [filter]`** - Does the same thing as `!ausclan` but '
+                f'[!bothelp]({url}) - Shows this help message about available commands.',
+                f'[!membercardsranked [clan_tag] [filter]]({url}) - Does same thing as `!ausclan` but '
                 'for the specific [clan_tag] instead.',
-                '**`!boatattack [clan_tag]`** - Does the same thing as `!ausclanboat` but for the specific [clan_tag] instead.'
+                f'[!boatattack [clan_tag]]({url}) - Does same thing as `!ausclanboat` but for the specific [clan_tag] instead.'
             ]
-            embed.add_field(name='Ausclan commands', value='\n\n'.join(ausclan_cmds), inline=False)
-            embed.add_field(name='Other commands', value='\n\n'.join(generic_cmds), inline=False)
+            embed.add_field(name='Ausclan commands', value='\n'.join(ausclan_cmds), inline=False)
+            embed.add_field(name='Other commands', value='\n'.join(generic_cmds), inline=False)
         await ctx.send(embed=embed)
 
     @bot.command()

--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ def main():
             )
             url = 'https://royaleapi.com/clan/9GULPJ9L/war/race'
             ausclan_cmds = [
-                f'[!ausclan \[filter\]]({url}) - Shows clan members ranked by number of high level cards they have. [filter] '
+                f'[!ausclan [filter]]({url}) - Shows clan members ranked by number of high level cards they have. [filter] '
                 'can be one of \'all\', \'troop\', \'spell\' or \'building\'. Defaults to \'all\' if not specified',
                 f'[!ausclanboat]({url}) - Lists clan members who attacked enemy boats this week.',
             ]

--- a/royale_api_website_scraper.py
+++ b/royale_api_website_scraper.py
@@ -1,5 +1,4 @@
 import re
-import socket
 from collections import OrderedDict
 
 import requests
@@ -58,7 +57,7 @@ class RoyaleApiWebsiteScraper:
 
         boat_attackers = [p for p in data if int(p[5]) > 0]
 
-        clan_logo = soup.find('a', {'class': 'active_clan'}).find('div',{'class': 'badge'}).find('img')['src']
+        clan_logo = soup.find('a', {'class': 'active_clan'}).find('div', {'class': 'badge'}).find('img')['src']
         clan_name = re.split(f' *#{clan_tag}', soup.find('title').string)[0]
         clan_info = {'name': clan_name, 'tag': f'#{clan_tag}', 'logo_url': clan_logo}
         return clan_info, boat_attackers


### PR DESCRIPTION
closes #26 
![image](https://user-images.githubusercontent.com/18656129/123516324-d506ab80-d6de-11eb-9fd6-e33ab7edeb2d.png)


@josephwccheng after you merge this can you put `!bothelp` in the "Playing" section? Similar to howthe Deck Shop bot has "Playing !info" as it's message. See screenshot below for what I mean by this
![image](https://user-images.githubusercontent.com/18656129/123515088-8c002880-d6d9-11eb-9be7-10409599c88d.png)
